### PR TITLE
Return promise instead of observable

### DIFF
--- a/src/ngx-restangular.ts
+++ b/src/ngx-restangular.ts
@@ -488,7 +488,7 @@ function providerConfig($http) {
           }
         });
         
-        return restangularizeResponse(subject, true, filledArray);
+        return restangularizeResponse(subject, true, filledArray).toPromise();
       }
       
       function withHttpConfig(httpConfig) {


### PR DESCRIPTION
Let ngx-restnagular return promise instead of observable in order to achieve compatibility between usage of Restangular and ngx-restangular